### PR TITLE
Added reject and cancel operations to the dashboard

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -28,7 +28,9 @@ class OrdersController < ApplicationController
   end
   
   def cancel
+    # Technically, we should not lose the accepted information here, maybe this can be solved by audit-logs
     @order = Order.find(params[:id])
+    @order.accepted_at = nil
     @order.cancelled_at = Time.now
     @order.save
     redirect_to "/dashboard"

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,6 +6,8 @@ class Order < ApplicationRecord
   delegate :description, to: :service
   delegate :price, to: :service
 
+  scope :unaccepted_rejected, -> { where(accepted_at: nil).where("rejected_at IS NOT NULL") }
+  scope :unaccepted_awaiting_response, -> { where(accepted_at: nil,rejected_at: nil) }
   scope :unaccepted, -> { where(accepted_at: nil) }
   scope :accepted, -> { where("accepted_at IS NOT NULL") }
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -45,7 +45,7 @@
                 <div class = "module per33 tab-per100 padding-medium">
                     <h3 class = "margin-bottom">Pending Incoming offers</h3>
 
-                    <%- current_user.orders.unaccepted.each do |order| -%>
+                    <%- current_user.orders.unaccepted_awaiting_response.each do |order| -%>
                       <div class = "panel-notification offer">
                           <p class = "panel-title bold"><%= order.headline %></p>
                           <span class = "panel-cost bold"><%= number_to_currency(order.price) %></span>


### PR DESCRIPTION
Also created two lists of unaccepted offers: rejected ones, and outstanding ones. Rejecting an offer now hides that offer.